### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/pkg/daemon/pods.go
+++ b/pkg/daemon/pods.go
@@ -136,7 +136,7 @@ func (pm *PodManager) AddPod(ctx context.Context, containerID, netnsPath, ifName
 	if err != nil {
 		return nil, fmt.Errorf("creating auth key: %w", err)
 	}
-	log.Printf("Got auth key for %s/%s: %s...", namespace, podName, authKey[:min(len(authKey), 20)])
+	log.Printf("Got auth key for %s/%s", namespace, podName)
 
 	podStateDir := filepath.Join(pm.stateDir, "pods", containerID)
 	if err := os.MkdirAll(podStateDir, 0700); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/jakedgy/tailscale-cni/security/code-scanning/1](https://github.com/jakedgy/tailscale-cni/security/code-scanning/1)

To fix the problem, the log line must be changed so that it no longer includes any portion of the `authKey` in clear text. Instead, the log can report non-sensitive metadata such as the pod identity and that an auth key was successfully created. If it is important to correlate logs to specific keys, a derived, non-sensitive identifier (e.g., a hash digest or a random ID generated alongside the key) could be logged instead, but we should not introduce such additional behavior without clear requirements, so the minimal safe change is simply to remove the key from the log message.

Concretely, in `pkg/daemon/pods.go` around line 139, replace:

```go
log.Printf("Got auth key for %s/%s: %s...", namespace, podName, authKey[:min(len(authKey), 20)])
```

with a version that omits the key, for example:

```go
log.Printf("Got auth key for %s/%s", namespace, podName)
```

This preserves existing functionality (the behavior of `authKey` itself is unchanged and still used later in the function), while removing the clear-text logging of sensitive data. No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
